### PR TITLE
[Fix]リザルトのストーリー演出を修正

### DIFF
--- a/Assets/Scripts/TitleAndSelectScene/StoryArchive.cs
+++ b/Assets/Scripts/TitleAndSelectScene/StoryArchive.cs
@@ -38,6 +38,10 @@ public class StoryArchive : MonoBehaviour
         {
             return _nextUnlockStoryId;
         }
+        set
+        {
+            _nextUnlockStoryId = value;
+        }
     }
 
     /*Unityä÷êî*/

--- a/Assets/Scripts/UI/RankIcon.cs
+++ b/Assets/Scripts/UI/RankIcon.cs
@@ -86,6 +86,9 @@ public class RankIcon : MonoBehaviour
         {
             _storyCanvas.GetComponent<PrologueBehv>().StoryPageArray = storyData._storyArray;
             _storyCanvas.SetActive(true);
+
+            StoryArchive.NextUnlockStoryId = StoryArchive.NextUnlockStoryId + 1;
+
             SystemSoundManager.Instance.BGMFade(0, 0.5f);
             transform.root.GetComponent<UnityEngine.InputSystem.PlayerInput>().SwitchCurrentActionMap("Player");
             return;


### PR DESCRIPTION
タイトルに戻らなずにプレイを続けると、クリア後に毎回同じストーリー演出が表示される不具合を修正